### PR TITLE
Feature/backend/cart only

### DIFF
--- a/src/main/java/com/_team/_project/domain/cart/api/response/GetCartResponse.java
+++ b/src/main/java/com/_team/_project/domain/cart/api/response/GetCartResponse.java
@@ -47,6 +47,16 @@ public class GetCartResponse {
                 .build();
     }
 
+    public static GetCartResponse empty() {
+        // 프로젝트 응답 규격에 맞춰 "없는 장바구니"를 빈 형태로 내려줌
+        // items는 반드시 빈 리스트로 내려줘야 FE에서 분기 줄어듦
+        return GetCartResponse.builder()
+                .cartId(null)
+                .storeId(null)
+                .items(java.util.List.of())
+                .build();
+    }
+
     @Getter
     @Builder
     public static class CartItemResponse {

--- a/src/main/java/com/_team/_project/domain/cart/entity/CartItem.java
+++ b/src/main/java/com/_team/_project/domain/cart/entity/CartItem.java
@@ -44,6 +44,7 @@ public class CartItem extends BaseEntity {
     private Integer quantity;
 
     @OneToMany(mappedBy = "cartItem", cascade = CascadeType.ALL, orphanRemoval = true)
+    @org.hibernate.annotations.BatchSize(size = 100)
     private List<CartItemOption> options = new ArrayList<>();
 
     public CartItem(Product product, Integer quantity) {

--- a/src/main/java/com/_team/_project/domain/cart/repository/CartRepositoryCustom.java
+++ b/src/main/java/com/_team/_project/domain/cart/repository/CartRepositoryCustom.java
@@ -15,4 +15,6 @@ public interface CartRepositoryCustom {
 
     // 유저의 활성 장바구니가 특정 storeId인지 확인(다른 가게 담기 정책 판단용)
     Optional<Cart> findActiveCartByUserId(UUID userId);
+
+    void fetchItemOptionsByCartId(UUID cartId);
 }

--- a/src/main/java/com/_team/_project/domain/cart/repository/CartRepositoryImpl.java
+++ b/src/main/java/com/_team/_project/domain/cart/repository/CartRepositoryImpl.java
@@ -19,49 +19,41 @@ public class CartRepositoryImpl implements CartRepositoryCustom {
 
     @Override
     public Optional<Cart> findActiveCartDetailByUserId(UUID userId) {
-        // ✅ 유저의 ACTIVE 장바구니를 "상세"로 조회
+        // 유저의 ACTIVE 장바구니를 "상세"로 조회
         // - cart + store + items + itemOptions 까지 한번에 가져오기(fetch join)
         // - 컬렉션(items/options) fetch join은 row가 늘어날 수 있어서 distinct로 중복 제거
-        return em.createQuery("""
-				select distinct c
-				from Cart c
-				join fetch c.store s
-				left join fetch c.items ci
-				left join fetch ci.options cio
-				left join fetch ci.product p
-				left join fetch cio.productOption po
-				left join fetch cio.productOptionItem poi
-				where c.user.id = :userId
-				  and c.status = :status
-				  and c.deletedAt is null
-			""", Cart.class)
-                .setParameter("userId", userId)
-                .setParameter("status", CartStatus.ACTIVE)
-                .getResultStream()
-                .findFirst();
+		return em.createQuery("""
+			select distinct c
+			from Cart c
+			join fetch c.store s
+			left join fetch c.items ci
+			left join fetch ci.product p
+			where c.user.id = :userId
+			  and c.status = :status
+			  and c.deletedAt is null
+		""", Cart.class)
+		.setParameter("userId", userId)
+		.setParameter("status", CartStatus.ACTIVE)
+		.getResultStream()
+		.findFirst();
     }
 
-    @Override
-    public Optional<Cart> findCartDetailById(UUID cartId) {
-        // ✅ cartId로 장바구니 "상세" 조회
-        // - 조회 화면에서 장바구니 상품/옵션까지 같이 보여주기 위함
-        return em.createQuery("""
-				select distinct c
-				from Cart c
-				join fetch c.user u
-				join fetch c.store s
-				left join fetch c.items ci
-				left join fetch ci.options cio
-				left join fetch ci.product p
-				left join fetch cio.productOption po
-				left join fetch cio.productOptionItem poi
-				where c.id = :cartId
-				  and c.deletedAt is null
-			""", Cart.class)
-                .setParameter("cartId", cartId)
-                .getResultStream()
-                .findFirst();
-    }
+	@Override
+	public Optional<Cart> findCartDetailById(UUID cartId) {
+		return em.createQuery("""
+        select distinct c
+        from Cart c
+        join fetch c.user u
+        join fetch c.store s
+        left join fetch c.items ci
+        left join fetch ci.product p
+        where c.id = :cartId
+          and c.deletedAt is null
+    """, Cart.class)
+				.setParameter("cartId", cartId)
+				.getResultStream()
+				.findFirst();
+	}
 
     @Override
     public Optional<Cart> findActiveCartByUserId(UUID userId) {
@@ -80,4 +72,22 @@ public class CartRepositoryImpl implements CartRepositoryCustom {
                 .getResultStream()
                 .findFirst();
     }
+
+	@Override
+	public void fetchItemOptionsByCartId(UUID cartId) {
+		// cart.items는 이미 1번 쿼리에서 fetch됨
+		// 여기서는 items.options만 한 번에 땡겨서 영속성 컨텍스트에 로딩시키는 용도
+		em.createQuery("""
+        select distinct c
+        from Cart c
+        join fetch c.items ci
+        left join fetch ci.options cio
+        left join fetch cio.productOption po
+        left join fetch cio.productOptionItem poi
+        where c.id = :cartId
+          and c.deletedAt is null
+    """, Cart.class)
+				.setParameter("cartId", cartId)
+				.getResultList();
+	}
 }

--- a/src/main/java/com/_team/_project/domain/cart/service/CartServiceImpl.java
+++ b/src/main/java/com/_team/_project/domain/cart/service/CartServiceImpl.java
@@ -47,9 +47,8 @@ public class CartServiceImpl implements CartService {
     private final com._team._project.domain.product.repository.ProductOptionItemRepository productOptionItemRepository;
 
     @Override
+    @Transactional // 또는 readOnly=true로 바꾸고 싶으면 spring 트랜잭션으로
     public GetCartResponse getCart(UUID userId) {
-
-        // ✅ 유저의 ACTIVE 장바구니 상세 조회(items/options 포함)
         Cart cart = cartRepository.findActiveCartDetailByUserId(userId)
                 .orElseThrow(CartNotFoundException::new);
 


### PR DESCRIPTION
🐛 Fix: 장바구니 조회 500/MultipleBagFetchException 수정

Cart 조회 쿼리에서 items/options 동시 fetch join을 제거하여 Hibernate 예외 해결
CartItem.options에 BatchSize 적용 및 getCart에 @Transactional 추가
장바구니 미존재 시 빈 응답(empty) 반환하도록 수정

Related to: #37

---

## 📌 개요

### 🧩 파트

- [x] BE
- [ ] FE

### 📝 작업 내용

- Cart 조회 시 발생하던 MultipleBagFetchException으로 인한 500 오류를 해결했습니다.
- 장바구니가 없는 경우에도 200 + empty(items: []) 형태로 응답하도록 처리했습니다.

#### PR 유형

어떤 변경 사항이 있나요?

- [ ] 완전히 새로운 파일 생성 / 초기 세팅(Add)
- [ ] 기능 추가 및 기존 기능 수정·확장 (비즈니스 로직 변경 포함)(Feat)
- [x] 버그 수정(Fix)
- [ ] 코드 리팩토링(Refactor)
- [ ] 코드 수정(Fix)
- [ ] 파일 옮김/정리(Move)
- [ ] 기능/파일을 삭제(Del)
- [ ] 테스트 코드를 작성(Test)
- [ ] css(Style)
- [ ] gitignore 수정(Gitfix)
- [ ] package.json 변경(npm 설치 등)(Script)
- [ ] 배포 관련 수정 (CI/CD, Docker, EC2 설정 등)(Deploy)
- [ ] Docker/Dockerfile/docker-compose 등 컨테이너 관련 변경(Docker)
- [ ] 자질구레한 일들(Chore)

#### 변경 영향 범위 (Impact)

- [x] API 스펙 변경 없음
- [ ] API 스펙 변경 있음 (하위 호환성 유지 O / X)
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션 포함 여부: O / X)
- [ ] 기존 기능에 영향 없음
- [x] 기존 기능에 영향 있음 (영향 범위 명시)

> 영향 범위: 장바구니 조회 응답(장바구니 미존재 시)이 500 → 200 + empty(items: [])로 변경됨

### 🖼 이미지 첨부(선택)

<!---- 필요한 경우, 이미지를 첨부해주세요. -->

### 🔗 이슈 번호 및 이슈 링크

- Related to: #37

Fixes #37
Resolves #37

---

## 🏷 PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

---

## 💬 리뷰 요구사항(선택)

- Cart 조회 쿼리/DTO 변환 흐름에서 N+1 가능성 및 성능 관점으로 추가 개선 포인트가 있는지 봐주세요.