### PR TITLE
🚀 [Deploy] GitHub Actions로 GHCR 이미지 빌드/푸시 자동화 (#56)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,62 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - develop  # develop push 시 배포
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1) 소스코드 체크아웃
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # 2) GHCR 로그인
+      - name: Login to GHCR
+        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USERNAME }}" --password-stdin
+
+      # 3) API 이미지 빌드 & 푸시 (EC2 compose에 적힌 경로 그대로!)
+      - name: Build & Push API Image
+        run: |
+          docker build -t ghcr.io/nbcamp-team-4/baegopang-api:latest .
+          docker push ghcr.io/nbcamp-team-4/baegopang-api:latest
+
+      # 4) Nginx 이미지 빌드 & 푸시 (EC2 compose에 적힌 경로 그대로!)
+      - name: Build & Push Nginx Image
+        run: |
+          docker build -t ghcr.io/nbcamp-team-4/baegopang-nginx:latest -f nginx/Dockerfile nginx
+          docker push ghcr.io/nbcamp-team-4/baegopang-nginx:latest
+
+  deploy-ec2:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+
+    steps:
+      # 5) EC2(Amazon Linux)에 SSH 접속해서 pull + up
+      - name: Deploy to Amazon Linux EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}   # ec2-user
+          key: ${{ secrets.EC2_SSH_KEY }}
+          port: 22
+          script: |
+            set -e
+
+            echo "✅ [1] GHCR 로그인 (EC2)"
+            docker login ghcr.io -u "${{ secrets.GHCR_USERNAME }}" -p "${{ secrets.GHCR_TOKEN }}"
+
+            echo "✅ [2] 배포 폴더 이동"
+            cd ~/baegopang
+
+            echo "✅ [3] 최신 이미지 pull"
+            docker compose pull
+
+            echo "✅ [4] 컨테이너 재기동"
+            docker compose up -d
+
+            echo "✅ [5] 상태 확인"
+            docker ps


### PR DESCRIPTION
Related to: #56

## 📌 개요
develop 브랜치에 push 될 때 API/Nginx Docker 이미지를 자동으로 빌드하고,
GHCR(ghcr.io)로 push하도록 GitHub Actions 워크플로우를 추가했습니다.

## 📝 작업 내용
- GitHub Actions 워크플로우 파일 추가
- GHCR 로그인 후 이미지 build/push 단계 구성
- (예상) EC2 배포 단계는 별도 이슈(#60)에서 진행

## ✅ 확인 방법
- develop 브랜치에 push
- GitHub Actions 탭에서 workflow 성공 여부 확인
- GHCR Packages에 최신 태그가 생성되었는지 확인